### PR TITLE
Add .dockerignore to minimize docker build upload

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.idea
+node_modules


### PR DESCRIPTION
I'm seeing a 278.9MB upload to do the docker build. Using a `.dockerignore` file to exclude `node_modules` takes that down to 1.6MB. This is an especially good idea since we're using the IBM Cloud Container Registry service to do the build for us.